### PR TITLE
Small fixes in some models and convert_model.py

### DIFF
--- a/convert_model.py
+++ b/convert_model.py
@@ -565,7 +565,7 @@ def parse_node_plantuml(line: str):
         if "--" in annotation:
             stereotypes.append(annotation.replace("-", "").strip())
         elif ":" in annotation:
-            tagged_values.append(annotation.strip())
+            tagged_values.append(annotation.replace("\\", "").strip())
 
     return name, stereotypes, tagged_values
 
@@ -579,12 +579,12 @@ def parse_flow_plantuml(line: str):
     sender = line.split("->")[0].strip()
     receiver = line.split("->")[1].split("[")[0].strip()
 
-    annotations = line.split("label = ")[1].split("]")
+    annotations = line.split("label = ")[1].split("]")[0].split("\\n")
     for annotation in annotations:
         if "--" in annotation:
             stereotypes.append(annotation.replace("-", "").replace("\"", "").replace("\\n", "").strip())
         elif ":" in annotation:
-            tagged_values.append(annotation.strip())
+            tagged_values.append(annotation.replace("\\", "").strip())
 
     return sender, receiver, stereotypes, tagged_values
 

--- a/dataset/ewolff_microservice/model_variants/18.txt
+++ b/dataset/ewolff_microservice/model_variants/18.txt
@@ -32,7 +32,7 @@ digraph dfd2{
         secret_manager [label = "{Process: secret_manager | --infrastructural--\n--secret_manager--}" shape = Mrecord];
         eureka -> secret_manager [label = " --restful_http--\n"]
         zuul -> secret_manager [label = " --restful_http--\n"]
-        turine -> secret_manager [label = " --restful_http--\n"]
+        turbine -> secret_manager [label = " --restful_http--\n"]
         catalog -> secret_manager [label = " --restful_http--\n"]
         customer -> secret_manager [label = " --restful_http--\n"]
         order -> secret_manager [label = " --restful_http--\n"]

--- a/dataset/piomin_sample-spring-oauth2-microservices/piomin_sample-spring-oauth2-microservices.json
+++ b/dataset/piomin_sample-spring-oauth2-microservices/piomin_sample-spring-oauth2-microservices.json
@@ -197,7 +197,7 @@
         {
             "name": "database_gateway_server",
             "stereotypes": [
-                "external_database"
+                "external_database",
                 "plaintext_credentials"
             ],
             "tagged_values": {

--- a/dataset/sqshq_piggymetrics/model_variants/10.txt
+++ b/dataset/sqshq_piggymetrics/model_variants/10.txt
@@ -66,7 +66,7 @@ digraph dfd2{
         registry -> monitoring [label = " --restful_http--"]
         rabbitmq -> monitoring [label = " --restful_http--"]
         account_service -> monitoring [label = " --restful_http--"]
-        auth_server -> monitoring [label = " --restful_http--"]
+        auth_service -> monitoring [label = " --restful_http--"]
         notification_service -> monitoring [label = " --restful_http--"]
         statistics_service -> monitoring [label = " --restful_http--"]
         gateway -> monitoring [label = " --restful_http--"]

--- a/dataset/sqshq_piggymetrics/model_variants/11.txt
+++ b/dataset/sqshq_piggymetrics/model_variants/11.txt
@@ -66,7 +66,7 @@ digraph dfd2{
         registry -> monitoring [label = " --restful_http--"]
         rabbitmq -> monitoring [label = " --restful_http--"]
         account_service -> monitoring [label = " --restful_http--"]
-        auth_server -> monitoring [label = " --restful_http--"]
+        auth_service -> monitoring [label = " --restful_http--"]
         notification_service -> monitoring [label = " --restful_http--"]
         statistics_service -> monitoring [label = " --restful_http--"]
         gateway -> monitoring [label = " --restful_http--"]

--- a/dataset/sqshq_piggymetrics/model_variants/12.txt
+++ b/dataset/sqshq_piggymetrics/model_variants/12.txt
@@ -66,7 +66,7 @@ digraph dfd2{
         registry -> rabbitmq [label = " --restful_http--"]
         rabbitmq -> monitoring [label = " --restful_http--"]
         account_service -> rabbitmq [label = " --restful_http--"]
-        auth_server -> rabbitmq [label = " --restful_http--"]
+        auth_service -> rabbitmq [label = " --restful_http--"]
         notification_service -> rabbitmq [label = " --restful_http--"]
         statistics_service -> rabbitmq [label = " --restful_http--"]
         gateway -> rabbitmq [label = " --restful_http--"]


### PR DESCRIPTION
This PR adresses some issues in the models and the converter script that we found during the integration into https://github.com/DataFlowAnalysis/DataFlowAnalysis/pull/128:

- Fixed sender typo in `sqshq_piggymetrics` variant 10, 11 and 12
- Fixed missing comma in `piomin_sample-spring-oauth2-microservices.json`
-  Fixed two errors in the converter when converting Plant to Json:
    - The linebreak split prevents mutiple tagged_values being pushed into one line in the JSON file.
    - The backslash removel prevents that one backslash per conversion is added to the name.

GaLiGrü aus Kerlsruhe