### PR TITLE
Fixed Bug in .txt files of model variants using the provided error_replacer.py

### DIFF
--- a/dataset/anilallewar_microservices-basics-spring-boot/model_variants/12.txt
+++ b/dataset/anilallewar_microservices-basics-spring-boot/model_variants/12.txt
@@ -49,7 +49,7 @@ digraph dfd2{
         auth_server -> api_gateway [label = " --restful_http--\n"]
         api_gateway -> user_webservice [label = " --restful_http--\n--load_balanced_link--\n--circuit_breaker_link--\n"]
         api_gateway -> task_webservice [label = " --restful_http--\n--load_balanced_link--\n--circuit_breaker_link--\n"]
-        message_broker [label = "{Process: message_broker | --infrastructural--\n--message_broker--}" shape = Mrecord];
+        message_broker [label = "{Process: message_broker | --infrastructural--\n--message_broker--\n}" shape = Mrecord];
         message_broker -> web_portal [label = " --restful_http--\n"]
         user_webservice -> message_broker [label = " --restful_http--\n"]
         comments_webservice -> message_broker [label = " --restful_http--\n"]

--- a/dataset/anilallewar_microservices-basics-spring-boot/model_variants/18.txt
+++ b/dataset/anilallewar_microservices-basics-spring-boot/model_variants/18.txt
@@ -49,7 +49,7 @@ digraph dfd2{
         auth_server -> api_gateway [label = " --restful_http--\n"]
         api_gateway -> user_webservice [label = " --restful_http--\n--load_balanced_link--\n--circuit_breaker_link--\n"]
         api_gateway -> task_webservice [label = " --restful_http--\n--load_balanced_link--\n--circuit_breaker_link--\n"]
-        secret_manager [label = "{Process: secret_manager | --infrastructural--\n--secret_manager--}" shape = Mrecord];
+        secret_manager [label = "{Process: secret_manager | --infrastructural--\n--secret_manager--\n}" shape = Mrecord];
         api_gateway -> secret_manager [label = " --restful_http--"]
         configserver -> secret_manager [label = " --restful_http--"]
         webservice_registry -> secret_manager [label = " --restful_http--"]

--- a/dataset/apssouza22_java-microservice/model_variants/18.txt
+++ b/dataset/apssouza22_java-microservice/model_variants/18.txt
@@ -57,7 +57,7 @@ digraph dfd2{
         mailer -> logstash [label = " --restful_http--\n"]
         jmx_monitoring [label = "{Process: jmx_monitoring | --internal--\n}" shape = Mrecord];
         todo_infra [label = "{Process: todo_infra | --internal--\n}" shape = Mrecord];
-        secret_manager [label = "{Process: secret_manager | --infrastructural-- \n --secret_manager--}" shape = Mrecord];
+        secret_manager [label = "{Process: secret_manager | --infrastructural-- \n --secret_manager--\n}" shape = Mrecord];
         config_server -> secret_manager [label = " --restful_http--\n"]
         admin -> secret_manager [label = " --restful_http--\n"]
         eureka_server -> secret_manager [label = " --restful_http--\n"]

--- a/dataset/callistaenterprise_blog-microservices/model_variants/18.txt
+++ b/dataset/callistaenterprise_blog-microservices/model_variants/18.txt
@@ -58,7 +58,7 @@ digraph dfd2{
         config_server -> edge_server [label = " --restful_http--\n"]
         edge_server -> auth_server [label = " --restful_http--\n"]
 
-        secret_manager [label = "{Process: secret_manager | --infrastructural-- \n --secret_manager--}" shape = Mrecord];
+        secret_manager [label = "{Process: secret_manager | --infrastructural-- \n --secret_manager--\n}" shape = Mrecord];
         elasticsearch -> secret_manager [label = " --restful_http--\n"]
         kibana -> secret_manager [label = " --restful_http--\n"]
         logstash -> secret_manager [label = " --restful_http--\n"]

--- a/dataset/error_replacer.py
+++ b/dataset/error_replacer.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import re
+
+def replace_in_file(file_path):
+    try:
+        if not file_path.exists():
+            print(f"File does not exist: {file_path}")
+            return
+
+        content = file_path.read_text(encoding='utf-8')
+        modified_content = re.sub(r'--\}', r'--\\n}', content)
+
+        if content != modified_content:
+            file_path.write_text(modified_content, encoding='utf-8')
+            print(f"Updated file: {file_path}")
+        else:
+            print(f"No changes needed: {file_path}")
+
+    except Exception as e:
+        print(f"Error processing file {file_path}: {e}")
+
+def process_all_subfolders(root_dir):
+    root_path = Path(root_dir)
+    # Using rglob to recursively find all .txt files
+    for file_path in root_path.rglob('*.txt'):
+        replace_in_file(file_path)
+
+# Example usage:
+root_dir = Path(r'put\your\root\dir\here') #set root dir
+process_all_subfolders(root_dir)

--- a/dataset/ewolff_microservice-kafka/model_variants/10.txt
+++ b/dataset/ewolff_microservice-kafka/model_variants/10.txt
@@ -29,8 +29,8 @@ digraph dfd2{
         postgres -> shipping [label = " --jdbc--\n--plaintext_credentials_link--\n'Username': dbuser\n 'Password': dbpass\n"]
         postgres -> invoicing [label = " --jdbc--\n--plaintext_credentials_link--\n'Username': dbuser\n 'Password': dbpass\n"]
 
-        monitoring_dashboard [label = "{Process: monitoring_dashboard | \n--infrastructural--\n--monitoring_dashboard--\n--local_logging--}" shape = Mrecord];
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--}" shape = Mrecord];
+        monitoring_dashboard [label = "{Process: monitoring_dashboard | \n--infrastructural--\n--monitoring_dashboard--\n--local_logging--\n}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n}" shape = Mrecord];
         logging_server -> monitoring_dashboard [label = " --restful_http--\n"]
         zookeeper -> logging_server [label = " --restful_http--\n"]
         kafka -> logging_server [label = " --restful_http--\n"]

--- a/dataset/ewolff_microservice-kafka/model_variants/11.txt
+++ b/dataset/ewolff_microservice-kafka/model_variants/11.txt
@@ -29,8 +29,8 @@ digraph dfd2{
         postgres -> shipping [label = " --jdbc--\n--plaintext_credentials_link--\n'Username': dbuser\n 'Password': dbpass\n"]
         postgres -> invoicing [label = " --jdbc--\n--plaintext_credentials_link--\n'Username': dbuser\n 'Password': dbpass\n"]
 
-        monitoring_dashboard [label = "{Process: monitoring_dashboard | \n--infrastructural--\n--monitoring_dashboard--\n--local_logging--}" shape = Mrecord];
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--}" shape = Mrecord];
+        monitoring_dashboard [label = "{Process: monitoring_dashboard | \n--infrastructural--\n--monitoring_dashboard--\n--local_logging--\n}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n}" shape = Mrecord];
         logging_server -> monitoring_dashboard [label = " --restful_http--\n"]
         zookeeper -> logging_server [label = " --restful_http--\n"]
         kafka -> logging_server [label = " --restful_http--\n"]

--- a/dataset/ewolff_microservice-kafka/model_variants/12.txt
+++ b/dataset/ewolff_microservice-kafka/model_variants/12.txt
@@ -29,8 +29,8 @@ digraph dfd2{
         postgres -> shipping [label = " --jdbc--\n--plaintext_credentials_link--\n'Username': dbuser\n 'Password': dbpass\n"]
         postgres -> invoicing [label = " --jdbc--\n--plaintext_credentials_link--\n'Username': dbuser\n 'Password': dbpass\n"]
 
-        monitoring_dashboard [label = "{Process: monitoring_dashboard | \n--infrastructural--\n--monitoring_dashboard--\n--local_logging--}" shape = Mrecord];
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--}" shape = Mrecord];
+        monitoring_dashboard [label = "{Process: monitoring_dashboard | \n--infrastructural--\n--monitoring_dashboard--\n--local_logging--\n}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n}" shape = Mrecord];
         logging_server -> monitoring_dashboard [label = " --restful_http--\n"]
         kafka -> logging_server [label = " --restful_http--\n"]
         zookeeper -> kafka [label = " --restful_http--\n"]

--- a/dataset/ewolff_microservice-kafka/model_variants/16.txt
+++ b/dataset/ewolff_microservice-kafka/model_variants/16.txt
@@ -29,7 +29,7 @@ digraph dfd2{
         postgres -> shipping [label = " --jdbc--\n--plaintext_credentials_link--\n'Username': dbuser\n 'Password': dbpass\n"]
         postgres -> invoicing [label = " --jdbc--\n--plaintext_credentials_link--\n'Username': dbuser\n 'Password': dbpass\n"]
 
-        service_discovery [label = "{Process: service_discovery | --infrastructural--\n--service_discovery--}" shape = Mrecord];
+        service_discovery [label = "{Process: service_discovery | --infrastructural--\n--service_discovery--\n}" shape = Mrecord];
         zookeeper -> service_discovery [label = " --restful_http--\n"]
         kafka -> service_discovery [label = " --restful_http--\n"]
         order -> service_discovery [label = " --restful_http--\n"]

--- a/dataset/ewolff_microservice-kafka/model_variants/17.txt
+++ b/dataset/ewolff_microservice-kafka/model_variants/17.txt
@@ -29,7 +29,7 @@ digraph dfd2{
         postgres -> shipping [label = " --jdbc--\n--plaintext_credentials_link--\n'Username': dbuser\n 'Password': dbpass\n"]
         postgres -> invoicing [label = " --jdbc--\n--plaintext_credentials_link--\n'Username': dbuser\n 'Password': dbpass\n"]
 
-        service_discovery [label = "{Process: service_discovery | --infrastructural--\n--service_discovery--\n--validate_registration--}" shape = Mrecord];
+        service_discovery [label = "{Process: service_discovery | --infrastructural--\n--service_discovery--\n--validate_registration--\n}" shape = Mrecord];
         zookeeper -> service_discovery [label = " --restful_http--\n"]
         kafka -> service_discovery [label = " --restful_http--\n"]
         order -> service_discovery [label = " --restful_http--\n"]

--- a/dataset/ewolff_microservice-kafka/model_variants/18.txt
+++ b/dataset/ewolff_microservice-kafka/model_variants/18.txt
@@ -29,7 +29,7 @@ digraph dfd2{
         postgres -> shipping [label = " --jdbc--\n--plaintext_credentials_link--\n'Username': dbuser\n 'Password': dbpass\n"]
         postgres -> invoicing [label = " --jdbc--\n--plaintext_credentials_link--\n'Username': dbuser\n 'Password': dbpass\n"]
 
-        secret_manager [label = "{Process: secret_manager | --infrastructural--\n--secret_manager--}" shape = Mrecord];
+        secret_manager [label = "{Process: secret_manager | --infrastructural--\n--secret_manager--\n}" shape = Mrecord];
         zookeeper -> secret_manager [label = " --restful_http--\n"]
         kafka -> secret_manager [label = " --restful_http--\n"]
         order -> secret_manager [label = " --restful_http--\n"]

--- a/dataset/ewolff_microservice-kafka/model_variants/3.txt
+++ b/dataset/ewolff_microservice-kafka/model_variants/3.txt
@@ -29,7 +29,7 @@ digraph dfd2{
         postgres -> shipping [label = " --jdbc--\n--plaintext_credentials_link--\n'Username': dbuser\n 'Password': dbpass\n"]
         postgres -> invoicing [label = " --jdbc--\n--plaintext_credentials_link--\n'Username': dbuser\n 'Password': dbpass\n"]
 
-        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--}" shape = Mrecord];
+        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--\n}" shape = Mrecord];
         authorization_server -> zookeeper [label = " --restful_http--\n"]
         authorization_server -> kafka [label = " --restful_http--\n"]
         authorization_server -> order [label = " --restful_http--\n"]

--- a/dataset/ewolff_microservice-kafka/model_variants/5.txt
+++ b/dataset/ewolff_microservice-kafka/model_variants/5.txt
@@ -29,7 +29,7 @@ digraph dfd2{
         postgres -> shipping [label = " --jdbc--\n--plaintext_credentials_link--\n'Username': dbuser\n 'Password': dbpass\n"]
         postgres -> invoicing [label = " --jdbc--\n--plaintext_credentials_link--\n'Username': dbuser\n 'Password': dbpass\n"]
 
-        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--}" shape = Mrecord];
+        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--\n}" shape = Mrecord];
         authorization_server -> zookeeper [label = " --restful_http--\n"]
         authorization_server -> kafka [label = " --restful_http--\n"]
         authorization_server -> order [label = " --restful_http--\n"]

--- a/dataset/ewolff_microservice-kafka/model_variants/6.txt
+++ b/dataset/ewolff_microservice-kafka/model_variants/6.txt
@@ -29,7 +29,7 @@ digraph dfd2{
         postgres -> shipping [label = " --jdbc--\n--plaintext_credentials_link--\n'Username': dbuser\n 'Password': dbpass\n"]
         postgres -> invoicing [label = " --jdbc--\n--plaintext_credentials_link--\n'Username': dbuser\n 'Password': dbpass\n"]
 
-        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--\n--login_attempts_regulation--}" shape = Mrecord];
+        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--\n--login_attempts_regulation--\n}" shape = Mrecord];
         authorization_server -> zookeeper [label = " --restful_http--\n"]
         authorization_server -> kafka [label = " --restful_http--\n"]
         authorization_server -> order [label = " --restful_http--\n"]

--- a/dataset/ewolff_microservice-kafka/model_variants/9.txt
+++ b/dataset/ewolff_microservice-kafka/model_variants/9.txt
@@ -29,8 +29,8 @@ digraph dfd2{
         postgres -> shipping [label = " --jdbc--\n--plaintext_credentials_link--\n'Username': dbuser\n 'Password': dbpass\n"]
         postgres -> invoicing [label = " --jdbc--\n--plaintext_credentials_link--\n'Username': dbuser\n 'Password': dbpass\n"]
 
-        monitoring_dashboard [label = "{Process: monitoring_dashboard | \n--infrastructural--\n--monitoring_dashboard--}" shape = Mrecord];
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--}" shape = Mrecord];
+        monitoring_dashboard [label = "{Process: monitoring_dashboard | \n--infrastructural--\n--monitoring_dashboard--\n}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n}" shape = Mrecord];
         logging_server -> monitoring_dashboard [label = " --restful_http--\n"]
 }
 @enduml

--- a/dataset/ewolff_microservice/model_variants/10.txt
+++ b/dataset/ewolff_microservice/model_variants/10.txt
@@ -29,8 +29,8 @@ digraph dfd2{
         zuul -> catalog [label = " --restful_http--\n"]
         zuul -> order [label = " --restful_http--\n"]
 
-        message_broker [label = "{Process: message_broker | --infrastructural--\n--message_broker--}" shape = Mrecord];
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--}" shape = Mrecord];
+        message_broker [label = "{Process: message_broker | --infrastructural--\n--message_broker--\n}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n}" shape = Mrecord];
         message_broker -> logging_server [label = " --restful_http--\n"]
         eureka -> message_broker [label = " --restful_http--\n"]
         zuul -> message_broker [label = " --restful_http--\n"]

--- a/dataset/ewolff_microservice/model_variants/12.txt
+++ b/dataset/ewolff_microservice/model_variants/12.txt
@@ -29,8 +29,8 @@ digraph dfd2{
         zuul -> catalog [label = " --restful_http--\n"]
         zuul -> order [label = " --restful_http--\n"]
 
-        message_broker [label = "{Process: message_broker | --infrastructural--\n--message_broker--}" shape = Mrecord];
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--}" shape = Mrecord];
+        message_broker [label = "{Process: message_broker | --infrastructural--\n--message_broker--\n}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n}" shape = Mrecord];
         message_broker -> logging_server [label = " --restful_http--\n"]
         eureka -> message_broker [label = " --restful_http--\n"]
         zuul -> message_broker [label = " --restful_http--\n"]

--- a/dataset/ewolff_microservice/model_variants/18.txt
+++ b/dataset/ewolff_microservice/model_variants/18.txt
@@ -29,7 +29,7 @@ digraph dfd2{
         zuul -> catalog [label = " --restful_http--\n"]
         zuul -> order [label = " --restful_http--\n"]
 
-        secret_manager [label = "{Process: secret_manager | --infrastructural--\n--secret_manager--}" shape = Mrecord];
+        secret_manager [label = "{Process: secret_manager | --infrastructural--\n--secret_manager--\n}" shape = Mrecord];
         eureka -> secret_manager [label = " --restful_http--\n"]
         zuul -> secret_manager [label = " --restful_http--\n"]
         turbine -> secret_manager [label = " --restful_http--\n"]

--- a/dataset/ewolff_microservice/model_variants/3.txt
+++ b/dataset/ewolff_microservice/model_variants/3.txt
@@ -29,7 +29,7 @@ digraph dfd2{
         zuul -> catalog [label = " --restful_http--\n"]
         zuul -> order [label = " --restful_http--\n"]
 
-        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--}" shape = Mrecord];
+        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--\n}" shape = Mrecord];
         eureka -> authorization_server [label = " --restful_http--\n"]
         zuul -> authorization_server [label = " --restful_http--\n"]
         turbine -> authorization_server [label = " --restful_http--\n"]

--- a/dataset/ewolff_microservice/model_variants/5.txt
+++ b/dataset/ewolff_microservice/model_variants/5.txt
@@ -29,7 +29,7 @@ digraph dfd2{
         zuul -> catalog [label = " --restful_http--\n"]
         zuul -> order [label = " --restful_http--\n"]
 
-        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--}" shape = Mrecord];
+        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--\n}" shape = Mrecord];
         eureka -> authorization_server [label = " --restful_http--\n"]
         zuul -> authorization_server [label = " --restful_http--\n"]
         turbine -> authorization_server [label = " --restful_http--\n"]

--- a/dataset/ewolff_microservice/model_variants/6.txt
+++ b/dataset/ewolff_microservice/model_variants/6.txt
@@ -29,7 +29,7 @@ digraph dfd2{
         zuul -> catalog [label = " --restful_http--\n"]
         zuul -> order [label = " --restful_http--\n"]
 
-        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--\n--login_attempts_regulation--}" shape = Mrecord];
+        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--\n--login_attempts_regulation--\n}" shape = Mrecord];
         eureka -> authorization_server [label = " --restful_http--\n"]
         zuul -> authorization_server [label = " --restful_http--\n"]
         turbine -> authorization_server [label = " --restful_http--\n"]

--- a/dataset/fernandoabcampos_spring-netflix-oss-microservices/model_variants/18.txt
+++ b/dataset/fernandoabcampos_spring-netflix-oss-microservices/model_variants/18.txt
@@ -44,7 +44,7 @@ digraph dfd2{
         edge_server -> statement_service [label = " --restful_http--\n"]
         edge_server -> card_statement_composite [label = " --restful_http--\n"]
 
-        secret_manager [label = "{Process: secret_manager | --infrastructural--\n--secret_manager--}" shape = Mrecord];
+        secret_manager [label = "{Process: secret_manager | --infrastructural--\n--secret_manager--\n}" shape = Mrecord];
         config_server -> secret_manager [label = " --restful_http--\n"]
         discovery_service -> secret_manager [label = " --restful_http--\n"]
         rabbitmq -> secret_manager [label = " --restful_http--\n"]

--- a/dataset/fernandoabcampos_spring-netflix-oss-microservices/model_variants/3.txt
+++ b/dataset/fernandoabcampos_spring-netflix-oss-microservices/model_variants/3.txt
@@ -44,7 +44,7 @@ digraph dfd2{
         edge_server -> statement_service [label = " --restful_http--\n"]
         edge_server -> card_statement_composite [label = " --restful_http--\n"]
 
-        auth_server [label = "{Process: auth_server | --infrastructural--\n--authorization_server--}" shape = Mrecord];
+        auth_server [label = "{Process: auth_server | --infrastructural--\n--authorization_server--\n}" shape = Mrecord];
         config_server -> auth_server [label = " --restful_http--\n"]
         discovery_service -> auth_server [label = " --restful_http--\n"]
         rabbitmq -> auth_server [label = " --restful_http--\n"]

--- a/dataset/fernandoabcampos_spring-netflix-oss-microservices/model_variants/5.txt
+++ b/dataset/fernandoabcampos_spring-netflix-oss-microservices/model_variants/5.txt
@@ -44,7 +44,7 @@ digraph dfd2{
         edge_server -> statement_service [label = " --restful_http--\n"]
         edge_server -> card_statement_composite [label = " --restful_http--\n"]
 
-        auth_server [label = "{Process: auth_server | --infrastructural--\n--authorization_server--}" shape = Mrecord];
+        auth_server [label = "{Process: auth_server | --infrastructural--\n--authorization_server--\n}" shape = Mrecord];
         config_server -> auth_server [label = " --restful_http--\n"]
         discovery_service -> auth_server [label = " --restful_http--\n"]
         rabbitmq -> auth_server [label = " --restful_http--\n"]

--- a/dataset/fernandoabcampos_spring-netflix-oss-microservices/model_variants/6.txt
+++ b/dataset/fernandoabcampos_spring-netflix-oss-microservices/model_variants/6.txt
@@ -44,7 +44,7 @@ digraph dfd2{
         edge_server -> statement_service [label = " --restful_http--\n"]
         edge_server -> card_statement_composite [label = " --restful_http--\n"]
 
-        auth_server [label = "{Process: auth_server | --infrastructural--\n--authorization_server--\n--login_attempts_regulation--}" shape = Mrecord];
+        auth_server [label = "{Process: auth_server | --infrastructural--\n--authorization_server--\n--login_attempts_regulation--\n}" shape = Mrecord];
         config_server -> auth_server [label = " --restful_http--\n"]
         discovery_service -> auth_server [label = " --restful_http--\n"]
         rabbitmq -> auth_server [label = " --restful_http--\n"]

--- a/dataset/georgwittberger_apache-spring-boot-microservice-example/model_variants/10.txt
+++ b/dataset/georgwittberger_apache-spring-boot-microservice-example/model_variants/10.txt
@@ -20,7 +20,7 @@ digraph dfd2{
         apache_server -> product_service [label = " --restful_http--\n"]
         apache_server -> content_service [label = " --restful_http--\n"]
 
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n--monitoring_dashboard--}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n--monitoring_dashboard--\n}" shape = Mrecord];
         apache_server -> logging_server [label = " --restful_http--\n"]
         content_service -> logging_server [label = " --restful_http--\n"]
         product_service -> logging_server [label = " --restful_http--\n"]

--- a/dataset/georgwittberger_apache-spring-boot-microservice-example/model_variants/11.txt
+++ b/dataset/georgwittberger_apache-spring-boot-microservice-example/model_variants/11.txt
@@ -20,7 +20,7 @@ digraph dfd2{
         apache_server -> product_service [label = " --restful_http--\n"]
         apache_server -> content_service [label = " --restful_http--\n"]
 
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n--monitoring_dashboard--}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n--monitoring_dashboard--\n}" shape = Mrecord];
         apache_server -> logging_server [label = " --restful_http--\n"]
         content_service -> logging_server [label = " --restful_http--\n"]
         product_service -> logging_server [label = " --restful_http--\n"]

--- a/dataset/georgwittberger_apache-spring-boot-microservice-example/model_variants/12.txt
+++ b/dataset/georgwittberger_apache-spring-boot-microservice-example/model_variants/12.txt
@@ -20,8 +20,8 @@ digraph dfd2{
         apache_server -> product_service [label = " --restful_http--\n"]
         apache_server -> content_service [label = " --restful_http--\n"]
 
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n--monitoring_dashboard--}" shape = Mrecord];
-        message_broker [label = "{Process: message_broker | --infrastructural--\n--message_broker--}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n--monitoring_dashboard--\n}" shape = Mrecord];
+        message_broker [label = "{Process: message_broker | --infrastructural--\n--message_broker--\n}" shape = Mrecord];
         message_broker -> logging_server [label = " --restful_http--\n"]
         apache_server -> message_broker [label = " --restful_http--\n"]
         content_service -> message_broker [label = " --restful_http--\n"]

--- a/dataset/georgwittberger_apache-spring-boot-microservice-example/model_variants/16.txt
+++ b/dataset/georgwittberger_apache-spring-boot-microservice-example/model_variants/16.txt
@@ -20,7 +20,7 @@ digraph dfd2{
         apache_server -> product_service [label = " --restful_http--\n"]
         apache_server -> content_service [label = " --restful_http--\n"]
 
-        service_discovery [label = "{Process: service_discovery | --infrastructural--\n--service_discovery--}" shape = Mrecord];
+        service_discovery [label = "{Process: service_discovery | --infrastructural--\n--service_discovery--\n}" shape = Mrecord];
         apache_server -> service_discovery [label = " --restful_http--\n"]
         content_service -> service_discovery [label = " --restful_http--\n"]
         product_service -> service_discovery [label = " --restful_http--\n"]

--- a/dataset/georgwittberger_apache-spring-boot-microservice-example/model_variants/17.txt
+++ b/dataset/georgwittberger_apache-spring-boot-microservice-example/model_variants/17.txt
@@ -20,7 +20,7 @@ digraph dfd2{
         apache_server -> product_service [label = " --restful_http--\n"]
         apache_server -> content_service [label = " --restful_http--\n"]
 
-        service_discovery [label = "{Process: service_discovery | --infrastructural--\n--service_discovery--\n--validate_registration--}" shape = Mrecord];
+        service_discovery [label = "{Process: service_discovery | --infrastructural--\n--service_discovery--\n--validate_registration--\n}" shape = Mrecord];
         apache_server -> service_discovery [label = " --restful_http--\n"]
         content_service -> service_discovery [label = " --restful_http--\n"]
         product_service -> service_discovery [label = " --restful_http--\n"]

--- a/dataset/georgwittberger_apache-spring-boot-microservice-example/model_variants/18.txt
+++ b/dataset/georgwittberger_apache-spring-boot-microservice-example/model_variants/18.txt
@@ -20,7 +20,7 @@ digraph dfd2{
         apache_server -> product_service [label = " --restful_http--\n"]
         apache_server -> content_service [label = " --restful_http--\n"]
 
-        secret_manager [label = "{Process: secret_manager | --infrastructural--\n--secret_manager--}" shape = Mrecord];
+        secret_manager [label = "{Process: secret_manager | --infrastructural--\n--secret_manager--\n}" shape = Mrecord];
         apache_server -> secret_manager [label = " --restful_http--\n"]
         content_service -> secret_manager [label = " --restful_http--\n"]
         product_service -> secret_manager [label = " --restful_http--\n"]

--- a/dataset/georgwittberger_apache-spring-boot-microservice-example/model_variants/3.txt
+++ b/dataset/georgwittberger_apache-spring-boot-microservice-example/model_variants/3.txt
@@ -19,7 +19,7 @@ digraph dfd2{
         apache_server -> cart_service [label = " --restful_http--\n"]
         apache_server -> product_service [label = " --restful_http--\n"]
         apache_server -> content_service [label = " --restful_http--\n"]
-        auth_server [label = "{Process: auth_server | --infrastructural--\n--authorization_server--}" shape = Mrecord];
+        auth_server [label = "{Process: auth_server | --infrastructural--\n--authorization_server--\n}" shape = Mrecord];
         auth_server -> apache_server [label = " --restful_http--\n"]
         auth_server -> content_service [label = " --restful_http--\n"]
         auth_server -> product_service [label = " --restful_http--\n"]

--- a/dataset/georgwittberger_apache-spring-boot-microservice-example/model_variants/5.txt
+++ b/dataset/georgwittberger_apache-spring-boot-microservice-example/model_variants/5.txt
@@ -19,7 +19,7 @@ digraph dfd2{
         apache_server -> cart_service [label = " --restful_http--\n"]
         apache_server -> product_service [label = " --restful_http--\n"]
         apache_server -> content_service [label = " --restful_http--\n"]
-        auth_server [label = "{Process: auth_server | --infrastructural--\n--authorization_server--}" shape = Mrecord];
+        auth_server [label = "{Process: auth_server | --infrastructural--\n--authorization_server--\n}" shape = Mrecord];
         auth_server -> apache_server [label = " --restful_http--\n"]
         auth_server -> content_service [label = " --restful_http--\n"]
         auth_server -> product_service [label = " --restful_http--\n"]

--- a/dataset/georgwittberger_apache-spring-boot-microservice-example/model_variants/6.txt
+++ b/dataset/georgwittberger_apache-spring-boot-microservice-example/model_variants/6.txt
@@ -19,7 +19,7 @@ digraph dfd2{
         apache_server -> cart_service [label = " --restful_http--\n"]
         apache_server -> product_service [label = " --restful_http--\n"]
         apache_server -> content_service [label = " --restful_http--\n"]
-        auth_server [label = "{Process: auth_server | --infrastructural--\n--authorization_server--\n--login_attempts_regulation--}" shape = Mrecord];
+        auth_server [label = "{Process: auth_server | --infrastructural--\n--authorization_server--\n--login_attempts_regulation--\n}" shape = Mrecord];
         auth_server -> apache_server [label = " --restful_http--\n"]
         auth_server -> content_service [label = " --restful_http--\n"]
         auth_server -> product_service [label = " --restful_http--\n"]

--- a/dataset/georgwittberger_apache-spring-boot-microservice-example/model_variants/9.txt
+++ b/dataset/georgwittberger_apache-spring-boot-microservice-example/model_variants/9.txt
@@ -20,7 +20,7 @@ digraph dfd2{
         apache_server -> product_service [label = " --restful_http--\n"]
         apache_server -> content_service [label = " --restful_http--\n"]
 
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n--monitoring_dashboard--}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n--monitoring_dashboard--\n}" shape = Mrecord];
 
 
 

--- a/dataset/jferrater_tap-and-eat-microservices/model_variants/1.txt
+++ b/dataset/jferrater_tap-and-eat-microservices/model_variants/1.txt
@@ -34,7 +34,7 @@ digraph dfd2{
         foodtray_service -> item_service [label = " --restful_http--\n--feign_connection--\n--load_balanced_link--\n--circuit_breaker_link--\n'Load Balancer': Ribbon\n 'Circuit Breaker': Hystrix\n"]
         foodtray_service -> price_service [label = " --restful_http--\n--feign_connection--\n--load_balanced_link--\n--circuit_breaker_link--\n'Load Balancer': Ribbon\n 'Circuit Breaker': Hystrix\n"]
 
-        gateway [label = "{Process: gateway | --infrastructural--\n--gateway--}" shape = Mrecord];
+        gateway [label = "{Process: gateway | --infrastructural--\n--gateway--\n}" shape = Mrecord];
         gateway -> account_service [label = " --restful_http--\n"]
         gateway -> customer_service [label = " --restful_http--\n"]
         gateway -> foodtray_service [label = " --restful_http--\n"]

--- a/dataset/jferrater_tap-and-eat-microservices/model_variants/10.txt
+++ b/dataset/jferrater_tap-and-eat-microservices/model_variants/10.txt
@@ -34,7 +34,7 @@ digraph dfd2{
         foodtray_service -> item_service [label = " --restful_http--\n--feign_connection--\n--load_balanced_link--\n--circuit_breaker_link--\n'Load Balancer': Ribbon\n 'Circuit Breaker': Hystrix\n"]
         foodtray_service -> price_service [label = " --restful_http--\n--feign_connection--\n--load_balanced_link--\n--circuit_breaker_link--\n'Load Balancer': Ribbon\n 'Circuit Breaker': Hystrix\n"]
 
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n}" shape = Mrecord];
         logging_server -> foodtray_service [label = " --restful_http--\n"]
         discovery_service -> logging_server [label = " --restful_http--\n"]
         config_service -> logging_server [label = " --restful_http--\n"]

--- a/dataset/jferrater_tap-and-eat-microservices/model_variants/11.txt
+++ b/dataset/jferrater_tap-and-eat-microservices/model_variants/11.txt
@@ -34,7 +34,7 @@ digraph dfd2{
         foodtray_service -> item_service [label = " --restful_http--\n--feign_connection--\n--load_balanced_link--\n--circuit_breaker_link--\n'Load Balancer': Ribbon\n 'Circuit Breaker': Hystrix\n"]
         foodtray_service -> price_service [label = " --restful_http--\n--feign_connection--\n--load_balanced_link--\n--circuit_breaker_link--\n'Load Balancer': Ribbon\n 'Circuit Breaker': Hystrix\n"]
 
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n}" shape = Mrecord];
         logging_server -> foodtray_service [label = " --restful_http--\n"]
         discovery_service -> logging_server [label = " --restful_http--\n"]
         config_service -> logging_server [label = " --restful_http--\n"]

--- a/dataset/jferrater_tap-and-eat-microservices/model_variants/12.txt
+++ b/dataset/jferrater_tap-and-eat-microservices/model_variants/12.txt
@@ -34,8 +34,8 @@ digraph dfd2{
         foodtray_service -> item_service [label = " --restful_http--\n--feign_connection--\n--load_balanced_link--\n--circuit_breaker_link--\n'Load Balancer': Ribbon\n 'Circuit Breaker': Hystrix\n"]
         foodtray_service -> price_service [label = " --restful_http--\n--feign_connection--\n--load_balanced_link--\n--circuit_breaker_link--\n'Load Balancer': Ribbon\n 'Circuit Breaker': Hystrix\n"]
 
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--}" shape = Mrecord];
-        message_broker [label = "{Process: message_broker | --infrastructural--\n--message_broker--}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n}" shape = Mrecord];
+        message_broker [label = "{Process: message_broker | --infrastructural--\n--message_broker--\n}" shape = Mrecord];
         message_broker -> logging_server [label = " --restful_http--\n"]
         logging_server -> foodtray_service [label = " --restful_http--\n"]
         discovery_service -> message_broker [label = " --restful_http--\n"]

--- a/dataset/jferrater_tap-and-eat-microservices/model_variants/18.txt
+++ b/dataset/jferrater_tap-and-eat-microservices/model_variants/18.txt
@@ -34,7 +34,7 @@ digraph dfd2{
         foodtray_service -> item_service [label = " --restful_http--\n--feign_connection--\n--load_balanced_link--\n--circuit_breaker_link--\n'Load Balancer': Ribbon\n 'Circuit Breaker': Hystrix\n"]
         foodtray_service -> price_service [label = " --restful_http--\n--feign_connection--\n--load_balanced_link--\n--circuit_breaker_link--\n'Load Balancer': Ribbon\n 'Circuit Breaker': Hystrix\n"]
 
-        secret_manager [label = "{Process: secret_manager | --infrastructural--\n--secret_manager--}" shape = Mrecord];
+        secret_manager [label = "{Process: secret_manager | --infrastructural--\n--secret_manager--\n}" shape = Mrecord];
         discovery_service -> secret_manager [label = " --restful_http--\n"]
         config_service -> secret_manager [label = " --restful_http--\n"]
         account_service -> secret_manager [label = " --restful_http--\n"]

--- a/dataset/jferrater_tap-and-eat-microservices/model_variants/3.txt
+++ b/dataset/jferrater_tap-and-eat-microservices/model_variants/3.txt
@@ -34,7 +34,7 @@ digraph dfd2{
         foodtray_service -> item_service [label = " --restful_http--\n--feign_connection--\n--load_balanced_link--\n--circuit_breaker_link--\n--authenticated_request--\n'Load Balancer': Ribbon\n 'Circuit Breaker': Hystrix\n"]
         foodtray_service -> price_service [label = " --restful_http--\n--feign_connection--\n--load_balanced_link--\n--circuit_breaker_link--\n--authenticated_request--\n'Load Balancer': Ribbon\n 'Circuit Breaker': Hystrix\n"]
 
-        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--}" shape = Mrecord];
+        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--\n}" shape = Mrecord];
         authorization_server -> discovery_service [label = " --restful_http--"]
         authorization_server -> config_service [label = " --restful_http--"]
         authorization_server -> account_service [label = " --restful_http--"]

--- a/dataset/jferrater_tap-and-eat-microservices/model_variants/4.txt
+++ b/dataset/jferrater_tap-and-eat-microservices/model_variants/4.txt
@@ -34,7 +34,7 @@ digraph dfd2{
         foodtray_service -> item_service [label = " --restful_http--\n--feign_connection--\n--load_balanced_link--\n--circuit_breaker_link--\n'Load Balancer': Ribbon\n 'Circuit Breaker': Hystrix\n"]
         foodtray_service -> price_service [label = " --restful_http--\n--feign_connection--\n--load_balanced_link--\n--circuit_breaker_link--\n'Load Balancer': Ribbon\n 'Circuit Breaker': Hystrix\n"]
 
-        gateway [label = "{Process: gateway | --infrastructural--\n--gateway--\n--transform_identity_representation--}" shape = Mrecord];
+        gateway [label = "{Process: gateway | --infrastructural--\n--gateway--\n--transform_identity_representation--\n}" shape = Mrecord];
         gateway -> account_service [label = " --restful_http--\n"]
         gateway -> customer_service [label = " --restful_http--\n"]
         gateway -> foodtray_service [label = " --restful_http--\n"]

--- a/dataset/jferrater_tap-and-eat-microservices/model_variants/5.txt
+++ b/dataset/jferrater_tap-and-eat-microservices/model_variants/5.txt
@@ -34,7 +34,7 @@ digraph dfd2{
         foodtray_service -> item_service [label = " --restful_http--\n--feign_connection--\n--load_balanced_link--\n--circuit_breaker_link--\n--authenticated_request--\n'Load Balancer': Ribbon\n 'Circuit Breaker': Hystrix\n"]
         foodtray_service -> price_service [label = " --restful_http--\n--feign_connection--\n--load_balanced_link--\n--circuit_breaker_link--\n--authenticated_request--\n'Load Balancer': Ribbon\n 'Circuit Breaker': Hystrix\n"]
 
-        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--}" shape = Mrecord];
+        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--\n}" shape = Mrecord];
         authorization_server -> discovery_service [label = " --restful_http--"]
         authorization_server -> config_service [label = " --restful_http--"]
         authorization_server -> account_service [label = " --restful_http--"]

--- a/dataset/jferrater_tap-and-eat-microservices/model_variants/6.txt
+++ b/dataset/jferrater_tap-and-eat-microservices/model_variants/6.txt
@@ -34,7 +34,7 @@ digraph dfd2{
         foodtray_service -> item_service [label = " --restful_http--\n--feign_connection--\n--load_balanced_link--\n--circuit_breaker_link--\n--authenticated_request--\n'Load Balancer': Ribbon\n 'Circuit Breaker': Hystrix\n"]
         foodtray_service -> price_service [label = " --restful_http--\n--feign_connection--\n--load_balanced_link--\n--circuit_breaker_link--\n--authenticated_request--\n'Load Balancer': Ribbon\n 'Circuit Breaker': Hystrix\n"]
 
-        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--\n--login_attempts_regulation--}" shape = Mrecord];
+        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--\n--login_attempts_regulation--\n}" shape = Mrecord];
         authorization_server -> discovery_service [label = " --restful_http--"]
         authorization_server -> config_service [label = " --restful_http--"]
         authorization_server -> account_service [label = " --restful_http--"]

--- a/dataset/jferrater_tap-and-eat-microservices/model_variants/9.txt
+++ b/dataset/jferrater_tap-and-eat-microservices/model_variants/9.txt
@@ -34,7 +34,7 @@ digraph dfd2{
         foodtray_service -> item_service [label = " --restful_http--\n--feign_connection--\n--load_balanced_link--\n--circuit_breaker_link--\n'Load Balancer': Ribbon\n 'Circuit Breaker': Hystrix\n"]
         foodtray_service -> price_service [label = " --restful_http--\n--feign_connection--\n--load_balanced_link--\n--circuit_breaker_link--\n'Load Balancer': Ribbon\n 'Circuit Breaker': Hystrix\n"]
 
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n}" shape = Mrecord];
         logging_server -> foodtray_service [label = " --restful_http--\n"]
 
 

--- a/dataset/koushikkothagal_spring-boot-microservices-workshop/model_variants/10.txt
+++ b/dataset/koushikkothagal_spring-boot-microservices-workshop/model_variants/10.txt
@@ -20,8 +20,8 @@ digraph dfd2{
         movie_catalog_service -> ratings_data_service [label = " --restful_http--\n--load_balanced_link--\n"]
         movie_catalog_service -> movie_info_service [label = " --restful_http--\n--load_balanced_link--\n"]
 
-        monitoring_dashboard [label = "{Process: monitoring_dashboard | \n--infrastructural--\n--monitoring_dashboard--}" shape = Mrecord];
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--}" shape = Mrecord];
+        monitoring_dashboard [label = "{Process: monitoring_dashboard | \n--infrastructural--\n--monitoring_dashboard--\n}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n}" shape = Mrecord];
         logging_server -> monitoring_dashboard [label = " --restful_http--\n"]
         discovery_server -> logging_server [label = " --restful_http--\n"]
         ratings_data_service -> logging_server [label = " --restful_http--\n"]

--- a/dataset/koushikkothagal_spring-boot-microservices-workshop/model_variants/11.txt
+++ b/dataset/koushikkothagal_spring-boot-microservices-workshop/model_variants/11.txt
@@ -20,8 +20,8 @@ digraph dfd2{
         movie_catalog_service -> ratings_data_service [label = " --restful_http--\n--load_balanced_link--\n"]
         movie_catalog_service -> movie_info_service [label = " --restful_http--\n--load_balanced_link--\n"]
 
-        monitoring_dashboard [label = "{Process: monitoring_dashboard | \n--infrastructural--\n--monitoring_dashboard--}" shape = Mrecord];
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--}" shape = Mrecord];
+        monitoring_dashboard [label = "{Process: monitoring_dashboard | \n--infrastructural--\n--monitoring_dashboard--\n}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n}" shape = Mrecord];
         logging_server -> monitoring_dashboard [label = " --restful_http--\n"]
         discovery_server -> logging_server [label = " --restful_http--\n"]
         ratings_data_service -> logging_server [label = " --restful_http--\n"]

--- a/dataset/koushikkothagal_spring-boot-microservices-workshop/model_variants/12.txt
+++ b/dataset/koushikkothagal_spring-boot-microservices-workshop/model_variants/12.txt
@@ -20,9 +20,9 @@ digraph dfd2{
         movie_catalog_service -> ratings_data_service [label = " --restful_http--\n--load_balanced_link--\n"]
         movie_catalog_service -> movie_info_service [label = " --restful_http--\n--load_balanced_link--\n"]
 
-        monitoring_dashboard [label = "{Process: monitoring_dashboard | \n--infrastructural--\n--monitoring_dashboard--}" shape = Mrecord];
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--}" shape = Mrecord];
-        message_broker [label = "{Process: message_broker | --infrastructural--\n--message_broker--}" shape = Mrecord];
+        monitoring_dashboard [label = "{Process: monitoring_dashboard | \n--infrastructural--\n--monitoring_dashboard--\n}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n}" shape = Mrecord];
+        message_broker [label = "{Process: message_broker | --infrastructural--\n--message_broker--\n}" shape = Mrecord];
         message_broker -> logging_server [label = " --restful_http--\n"]
         logging_server -> monitoring_dashboard [label = " --restful_http--\n"]
         discovery_server -> message_broker [label = " --restful_http--\n"]

--- a/dataset/koushikkothagal_spring-boot-microservices-workshop/model_variants/18.txt
+++ b/dataset/koushikkothagal_spring-boot-microservices-workshop/model_variants/18.txt
@@ -20,7 +20,7 @@ digraph dfd2{
         movie_catalog_service -> ratings_data_service [label = " --restful_http--\n--load_balanced_link--\n"]
         movie_catalog_service -> movie_info_service [label = " --restful_http--\n--load_balanced_link--\n"]
 
-        secret_manager [label = "{Process: secret_manager | --infrastructural--\n--secret_manager--}" shape = Mrecord];
+        secret_manager [label = "{Process: secret_manager | --infrastructural--\n--secret_manager--\n}" shape = Mrecord];
         secret_manager -> discovery_server [label = " --restful_http--\n"]
         secret_manager -> movie_info_service [label = " --restful_http--\n"]
         secret_manager -> movie_catalog_service [label = " --restful_http--\n"]

--- a/dataset/koushikkothagal_spring-boot-microservices-workshop/model_variants/3.txt
+++ b/dataset/koushikkothagal_spring-boot-microservices-workshop/model_variants/3.txt
@@ -20,7 +20,7 @@ digraph dfd2{
         movie_catalog_service -> ratings_data_service [label = " --restful_http--\n--load_balanced_link--\n"]
         movie_catalog_service -> movie_info_service [label = " --restful_http--\n--load_balanced_link--\n"]
 
-        auth_server [label = "{Process: auth_server | --infrastructural--\n--authorization_server--}" shape = Mrecord];
+        auth_server [label = "{Process: auth_server | --infrastructural--\n--authorization_server--\n}" shape = Mrecord];
         auth_server -> discovery_server [label = " --restful_http--\n"]
         auth_server -> movie_info_service [label = " --restful_http--\n"]
         auth_server -> movie_catalog_service [label = " --restful_http--\n"]

--- a/dataset/koushikkothagal_spring-boot-microservices-workshop/model_variants/5.txt
+++ b/dataset/koushikkothagal_spring-boot-microservices-workshop/model_variants/5.txt
@@ -20,7 +20,7 @@ digraph dfd2{
         movie_catalog_service -> ratings_data_service [label = " --restful_http--\n--load_balanced_link--\n"]
         movie_catalog_service -> movie_info_service [label = " --restful_http--\n--load_balanced_link--\n"]
 
-        auth_server [label = "{Process: auth_server | --infrastructural--\n--authorization_server--}" shape = Mrecord];
+        auth_server [label = "{Process: auth_server | --infrastructural--\n--authorization_server--\n}" shape = Mrecord];
         auth_server -> discovery_server [label = " --restful_http--\n"]
         auth_server -> movie_info_service [label = " --restful_http--\n"]
         auth_server -> movie_catalog_service [label = " --restful_http--\n"]

--- a/dataset/koushikkothagal_spring-boot-microservices-workshop/model_variants/6.txt
+++ b/dataset/koushikkothagal_spring-boot-microservices-workshop/model_variants/6.txt
@@ -20,7 +20,7 @@ digraph dfd2{
         movie_catalog_service -> ratings_data_service [label = " --restful_http--\n--load_balanced_link--\n"]
         movie_catalog_service -> movie_info_service [label = " --restful_http--\n--load_balanced_link--\n"]
 
-        auth_server [label = "{Process: auth_server | --infrastructural--\n--authorization_server--\n--login_attempts_regulation--}" shape = Mrecord];
+        auth_server [label = "{Process: auth_server | --infrastructural--\n--authorization_server--\n--login_attempts_regulation--\n}" shape = Mrecord];
         auth_server -> discovery_server [label = " --restful_http--\n"]
         auth_server -> movie_info_service [label = " --restful_http--\n"]
         auth_server -> movie_catalog_service [label = " --restful_http--\n"]

--- a/dataset/koushikkothagal_spring-boot-microservices-workshop/model_variants/9.txt
+++ b/dataset/koushikkothagal_spring-boot-microservices-workshop/model_variants/9.txt
@@ -20,8 +20,8 @@ digraph dfd2{
         movie_catalog_service -> ratings_data_service [label = " --restful_http--\n--load_balanced_link--\n"]
         movie_catalog_service -> movie_info_service [label = " --restful_http--\n--load_balanced_link--\n"]
 
-        monitoring_dashboard [label = "{Process: monitoring_dashboard | \n--infrastructural--\n--monitoring_dashboard--}" shape = Mrecord];
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--}" shape = Mrecord];
+        monitoring_dashboard [label = "{Process: monitoring_dashboard | \n--infrastructural--\n--monitoring_dashboard--\n}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n}" shape = Mrecord];
         logging_server -> monitoring_dashboard [label = " --restful_http--\n"]
 
 

--- a/dataset/mdeket_spring-cloud-movie-recommendation/model_variants/12.txt
+++ b/dataset/mdeket_spring-cloud-movie-recommendation/model_variants/12.txt
@@ -38,7 +38,7 @@ digraph dfd2{
         recommendation_client -> movie_service [label = " --restful_http--\n--circuit_breaker_link--\n--load_balanced_link--\n--feign_connection--\n'Circuit Breaker': Hystrix\n 'Load Balancer': Ribbon\n"]
         recommendation_client -> user_service [label = " --restful_http--\n--load_balanced_link--\n--circuit_breaker_link--\n--feign_connection--\n'Load Balancer': Ribbon\n 'Circuit Breaker': Hystrix\n"]
 
-        message_broker [label = "{Process: message_broker | --infrastructural--\n--message_broker--}" shape = Mrecord];
+        message_broker [label = "{Process: message_broker | --infrastructural--\n--message_broker--\n}" shape = Mrecord];
         message_broker -> recommendation_client [label = " --restful_http--\n"]
         config_service -> message_broker [label = " --restful_http--\n"]
         eureka_service -> message_broker [label = " --restful_http--\n"]

--- a/dataset/mdeket_spring-cloud-movie-recommendation/model_variants/3.txt
+++ b/dataset/mdeket_spring-cloud-movie-recommendation/model_variants/3.txt
@@ -38,7 +38,7 @@ digraph dfd2{
         recommendation_client -> movie_service [label = " --restful_http--\n--circuit_breaker_link--\n--load_balanced_link--\n--feign_connection--\n'Circuit Breaker': Hystrix\n 'Load Balancer': Ribbon\n"]
         recommendation_client -> user_service [label = " --restful_http--\n--load_balanced_link--\n--circuit_breaker_link--\n--feign_connection--\n'Load Balancer': Ribbon\n 'Circuit Breaker': Hystrix\n"]
 
-        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--}" shape = Mrecord];
+        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--\n}" shape = Mrecord];
         config_service -> authorization_server [label = " --restful_http--\n"]
         eureka_service -> authorization_server [label = " --restful_http--\n"]
         movie_service -> authorization_server [label = " --restful_http--\n"]

--- a/dataset/mdeket_spring-cloud-movie-recommendation/model_variants/5.txt
+++ b/dataset/mdeket_spring-cloud-movie-recommendation/model_variants/5.txt
@@ -38,7 +38,7 @@ digraph dfd2{
         recommendation_client -> movie_service [label = " --restful_http--\n--circuit_breaker_link--\n--load_balanced_link--\n--feign_connection--\n'Circuit Breaker': Hystrix\n 'Load Balancer': Ribbon\n"]
         recommendation_client -> user_service [label = " --restful_http--\n--load_balanced_link--\n--circuit_breaker_link--\n--feign_connection--\n'Load Balancer': Ribbon\n 'Circuit Breaker': Hystrix\n"]
 
-        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--}" shape = Mrecord];
+        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--\n}" shape = Mrecord];
         config_service -> authorization_server [label = " --restful_http--\n"]
         eureka_service -> authorization_server [label = " --restful_http--\n"]
         movie_service -> authorization_server [label = " --restful_http--\n"]

--- a/dataset/mdeket_spring-cloud-movie-recommendation/model_variants/6.txt
+++ b/dataset/mdeket_spring-cloud-movie-recommendation/model_variants/6.txt
@@ -38,7 +38,7 @@ digraph dfd2{
         recommendation_client -> movie_service [label = " --restful_http--\n--circuit_breaker_link--\n--load_balanced_link--\n--feign_connection--\n'Circuit Breaker': Hystrix\n 'Load Balancer': Ribbon\n"]
         recommendation_client -> user_service [label = " --restful_http--\n--load_balanced_link--\n--circuit_breaker_link--\n--feign_connection--\n'Load Balancer': Ribbon\n 'Circuit Breaker': Hystrix\n"]
 
-        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--\n--login_attempts_regulation--}" shape = Mrecord];
+        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--\n--login_attempts_regulation--\n}" shape = Mrecord];
         config_service -> authorization_server [label = " --restful_http--\n"]
         eureka_service -> authorization_server [label = " --restful_http--\n"]
         movie_service -> authorization_server [label = " --restful_http--\n"]

--- a/dataset/mudigal-technologies_microservices-sample/model_variants/18.txt
+++ b/dataset/mudigal-technologies_microservices-sample/model_variants/18.txt
@@ -58,7 +58,7 @@ digraph dfd2{
         elasticsearch -> scope [label = " --restful_http--\n"]
         logstash -> scope [label = " --restful_http--\n"]
 
-        secret_manager [label = "{Process: secret_manager | --infrastructural--\n--secret_manager--}" shape = Mrecord];
+        secret_manager [label = "{Process: secret_manager | --infrastructural--\n--secret_manager--\n}" shape = Mrecord];
         consul -> secret_manager [label = " --restful_http--\n"]
         consul2 -> secret_manager [label = " --restful_http--\n"]
         consul3 -> secret_manager [label = " --restful_http--\n"]

--- a/dataset/mudigal-technologies_microservices-sample/model_variants/3.txt
+++ b/dataset/mudigal-technologies_microservices-sample/model_variants/3.txt
@@ -58,7 +58,7 @@ digraph dfd2{
         elasticsearch -> scope [label = " --restful_http--\n"]
         logstash -> scope [label = " --restful_http--\n"]
 
-        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--}" shape = Mrecord];
+        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--\n}" shape = Mrecord];
         consul -> authorization_server [label = " --restful_http--\n"]
         consul2 -> authorization_server [label = " --restful_http--\n"]
         consul3 -> authorization_server [label = " --restful_http--\n"]

--- a/dataset/mudigal-technologies_microservices-sample/model_variants/5.txt
+++ b/dataset/mudigal-technologies_microservices-sample/model_variants/5.txt
@@ -58,7 +58,7 @@ digraph dfd2{
         elasticsearch -> scope [label = " --restful_http--\n"]
         logstash -> scope [label = " --restful_http--\n"]
 
-        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--}" shape = Mrecord];
+        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--\n}" shape = Mrecord];
         consul -> authorization_server [label = " --restful_http--\n"]
         consul2 -> authorization_server [label = " --restful_http--\n"]
         consul3 -> authorization_server [label = " --restful_http--\n"]

--- a/dataset/mudigal-technologies_microservices-sample/model_variants/6.txt
+++ b/dataset/mudigal-technologies_microservices-sample/model_variants/6.txt
@@ -58,7 +58,7 @@ digraph dfd2{
         elasticsearch -> scope [label = " --restful_http--\n"]
         logstash -> scope [label = " --restful_http--\n"]
 
-        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--\n--login_attempts_regulation--}" shape = Mrecord];
+        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--\n--login_attempts_regulation--\n}" shape = Mrecord];
         consul -> authorization_server [label = " --restful_http--\n"]
         consul2 -> authorization_server [label = " --restful_http--\n"]
         consul3 -> authorization_server [label = " --restful_http--\n"]

--- a/dataset/piomin_sample-spring-oauth2-microservices/model_variants/10.txt
+++ b/dataset/piomin_sample-spring-oauth2-microservices/model_variants/10.txt
@@ -30,8 +30,8 @@ digraph dfd2{
         customer_service -> account_service [label = " --restful_http--\n--authenticated_request--\n--feign_connection--\n--load_balanced_link--\n'Load Balancer': Ribbon\n"]
         auth_server -> customer_service [label = " --restful_http--\n--auth_provider--\n"]
 
-        monitoring_dashboard [label = "{Process: monitoring_dashboard | \n--infrastructural--\n--monitoring_dashboard--\n--local_logging--}" shape = Mrecord];
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--}" shape = Mrecord];
+        monitoring_dashboard [label = "{Process: monitoring_dashboard | \n--infrastructural--\n--monitoring_dashboard--\n--local_logging--\n}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n}" shape = Mrecord];
         logging_server -> monitoring_dashboard [label = " --restful_http--\n"]
         discovery_server -> logging_server [label = " --restful_http--\n"]
         gateway_server -> logging_server [label = " --restful_http--\n"]

--- a/dataset/piomin_sample-spring-oauth2-microservices/model_variants/11.txt
+++ b/dataset/piomin_sample-spring-oauth2-microservices/model_variants/11.txt
@@ -30,8 +30,8 @@ digraph dfd2{
         customer_service -> account_service [label = " --restful_http--\n--authenticated_request--\n--feign_connection--\n--load_balanced_link--\n'Load Balancer': Ribbon\n"]
         auth_server -> customer_service [label = " --restful_http--\n--auth_provider--\n"]
 
-        monitoring_dashboard [label = "{Process: monitoring_dashboard | \n--infrastructural--\n--monitoring_dashboard--\n--local_logging--}" shape = Mrecord];
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--}" shape = Mrecord];
+        monitoring_dashboard [label = "{Process: monitoring_dashboard | \n--infrastructural--\n--monitoring_dashboard--\n--local_logging--\n}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n}" shape = Mrecord];
         logging_server -> monitoring_dashboard [label = " --restful_http--\n"]
         discovery_server -> logging_server [label = " --restful_http--\n"]
         gateway_server -> logging_server [label = " --restful_http--\n"]

--- a/dataset/piomin_sample-spring-oauth2-microservices/model_variants/12.txt
+++ b/dataset/piomin_sample-spring-oauth2-microservices/model_variants/12.txt
@@ -30,9 +30,9 @@ digraph dfd2{
         customer_service -> account_service [label = " --restful_http--\n--authenticated_request--\n--feign_connection--\n--load_balanced_link--\n'Load Balancer': Ribbon\n"]
         auth_server -> customer_service [label = " --restful_http--\n--auth_provider--\n"]
 
-        monitoring_dashboard [label = "{Process: monitoring_dashboard | \n--infrastructural--\n--monitoring_dashboard--\n--local_logging--}" shape = Mrecord];
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--}" shape = Mrecord];
-        message_broker [label = "{Process: message_broker | --infrastructural--\n--message_broker--}" shape = Mrecord];
+        monitoring_dashboard [label = "{Process: monitoring_dashboard | \n--infrastructural--\n--monitoring_dashboard--\n--local_logging--\n}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n}" shape = Mrecord];
+        message_broker [label = "{Process: message_broker | --infrastructural--\n--message_broker--\n}" shape = Mrecord];
         message_broker -> logging_server [label = " --restful_http--\n"]
         logging_server -> monitoring_dashboard [label = " --restful_http--\n"]
         discovery_server -> message_broker [label = " --restful_http--\n"]

--- a/dataset/piomin_sample-spring-oauth2-microservices/model_variants/18.txt
+++ b/dataset/piomin_sample-spring-oauth2-microservices/model_variants/18.txt
@@ -30,7 +30,7 @@ digraph dfd2{
         customer_service -> account_service [label = " --restful_http--\n--authenticated_request--\n--feign_connection--\n--load_balanced_link--\n'Load Balancer': Ribbon\n"]
         auth_server -> customer_service [label = " --restful_http--\n--auth_provider--\n"]
 
-        secret_manager [label = "{Process: secret_manager | --infrastructural--\n--secret_manager--}" shape = Mrecord];
+        secret_manager [label = "{Process: secret_manager | --infrastructural--\n--secret_manager--\n}" shape = Mrecord];
         secret_manager -> discovery_server [label = " --restful_http--\n"]
         secret_manager -> gateway_server [label = " --restful_http--\n"]
         secret_manager -> auth_server [label = " --restful_http--\n"]

--- a/dataset/piomin_sample-spring-oauth2-microservices/model_variants/9.txt
+++ b/dataset/piomin_sample-spring-oauth2-microservices/model_variants/9.txt
@@ -30,8 +30,8 @@ digraph dfd2{
         customer_service -> account_service [label = " --restful_http--\n--authenticated_request--\n--feign_connection--\n--load_balanced_link--\n'Load Balancer': Ribbon\n"]
         auth_server -> customer_service [label = " --restful_http--\n--auth_provider--\n"]
 
-        monitoring_dashboard [label = "{Process: monitoring_dashboard | \n--infrastructural--\n--monitoring_dashboard--}" shape = Mrecord];
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--}" shape = Mrecord];
+        monitoring_dashboard [label = "{Process: monitoring_dashboard | \n--infrastructural--\n--monitoring_dashboard--\n}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n}" shape = Mrecord];
         logging_server -> monitoring_dashboard [label = " --restful_http--\n"]
 
 

--- a/dataset/rohitghatol_spring-boot-microservices/model_variants/10.txt
+++ b/dataset/rohitghatol_spring-boot-microservices/model_variants/10.txt
@@ -46,7 +46,7 @@ digraph dfd2{
         configserver -> api_gateway [label = " --restful_http--\n"]
         webservice_registry -> api_gateway [label = " --restful_http--\n"]
 
-        logging_server [label = "{Process: logging_server | \n--infrastructural--\n--logging_server--\n--monitoring_dashboard--}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | \n--infrastructural--\n--logging_server--\n--monitoring_dashboard--\n}" shape = Mrecord];
         configserver -> logging_server [label = " --restful_http--\n"]
         webservice_registry -> logging_server [label = " --restful_http--\n"]
         auth_server -> logging_server [label = " --restful_http--\n"]

--- a/dataset/rohitghatol_spring-boot-microservices/model_variants/11.txt
+++ b/dataset/rohitghatol_spring-boot-microservices/model_variants/11.txt
@@ -46,7 +46,7 @@ digraph dfd2{
         configserver -> api_gateway [label = " --restful_http--\n"]
         webservice_registry -> api_gateway [label = " --restful_http--\n"]
 
-        logging_server [label = "{Process: logging_server | \n--infrastructural--\n--logging_server--\n--monitoring_dashboard--}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | \n--infrastructural--\n--logging_server--\n--monitoring_dashboard--\n}" shape = Mrecord];
         configserver -> logging_server [label = " --restful_http--\n"]
         webservice_registry -> logging_server [label = " --restful_http--\n"]
         auth_server -> logging_server [label = " --restful_http--\n"]

--- a/dataset/rohitghatol_spring-boot-microservices/model_variants/12.txt
+++ b/dataset/rohitghatol_spring-boot-microservices/model_variants/12.txt
@@ -46,8 +46,8 @@ digraph dfd2{
         configserver -> api_gateway [label = " --restful_http--\n"]
         webservice_registry -> api_gateway [label = " --restful_http--\n"]
 
-        logging_server [label = "{Process: logging_server | \n--infrastructural--\n--logging_server--\n--monitoring_dashboard--}" shape = Mrecord];
-        message_broker [label = "{Process: message_broker | --infrastructural--\n--message_broker--}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | \n--infrastructural--\n--logging_server--\n--monitoring_dashboard--\n}" shape = Mrecord];
+        message_broker [label = "{Process: message_broker | --infrastructural--\n--message_broker--\n}" shape = Mrecord];
         message_broker -> logging_server [label = " --restful_http--\n"]
         configserver -> message_broker [label = " --restful_http--\n"]
         webservice_registry -> message_broker [label = " --restful_http--\n"]

--- a/dataset/rohitghatol_spring-boot-microservices/model_variants/18.txt
+++ b/dataset/rohitghatol_spring-boot-microservices/model_variants/18.txt
@@ -46,7 +46,7 @@ digraph dfd2{
         configserver -> api_gateway [label = " --restful_http--\n"]
         webservice_registry -> api_gateway [label = " --restful_http--\n"]
 
-        secret_manager [label = "{Process: secret_manager | --infrastructural--\n--secret_manager--}" shape = Mrecord];
+        secret_manager [label = "{Process: secret_manager | --infrastructural--\n--secret_manager--\n}" shape = Mrecord];
         configserver -> secret_manager [label = " --restful_http--\n"]
         webservice_registry -> secret_manager [label = " --restful_http--\n"]
         auth_server -> secret_manager [label = " --restful_http--\n"]

--- a/dataset/rohitghatol_spring-boot-microservices/model_variants/9.txt
+++ b/dataset/rohitghatol_spring-boot-microservices/model_variants/9.txt
@@ -46,7 +46,7 @@ digraph dfd2{
         configserver -> api_gateway [label = " --restful_http--\n"]
         webservice_registry -> api_gateway [label = " --restful_http--\n"]
 
-        logging_server [label = "{Process: logging_server | \n--infrastructural--\n--logging_server--\n--monitoring_dashboard--}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | \n--infrastructural--\n--logging_server--\n--monitoring_dashboard--\n}" shape = Mrecord];
 
 
 }

--- a/dataset/shabbirdwd53_springboot-microservice/model_variants/10.txt
+++ b/dataset/shabbirdwd53_springboot-microservice/model_variants/10.txt
@@ -36,7 +36,7 @@ digraph dfd2{
         api_gateway -> department_service [label = " --restful_http--\n--circuit_breaker_link--\n"]
         zipkin_server -> hystrix_dashboard [label = " --restful_http--\n"]
 
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n}" shape = Mrecord];
         logging_server -> hystrix_dashboard [label = " --restful_http--\n"]
         service_registry -> logging_server [label = " --restful_http--\n"]
         config_server -> logging_server [label = " --restful_http--\n"]

--- a/dataset/shabbirdwd53_springboot-microservice/model_variants/11.txt
+++ b/dataset/shabbirdwd53_springboot-microservice/model_variants/11.txt
@@ -36,7 +36,7 @@ digraph dfd2{
         api_gateway -> department_service [label = " --restful_http--\n--circuit_breaker_link--\n"]
         zipkin_server -> hystrix_dashboard [label = " --restful_http--\n"]
 
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n}" shape = Mrecord];
         logging_server -> hystrix_dashboard [label = " --restful_http--\n"]
         service_registry -> logging_server [label = " --restful_http--\n"]
         config_server -> logging_server [label = " --restful_http--\n"]

--- a/dataset/shabbirdwd53_springboot-microservice/model_variants/12.txt
+++ b/dataset/shabbirdwd53_springboot-microservice/model_variants/12.txt
@@ -36,8 +36,8 @@ digraph dfd2{
         api_gateway -> department_service [label = " --restful_http--\n--circuit_breaker_link--\n"]
         zipkin_server -> hystrix_dashboard [label = " --restful_http--\n"]
 
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--}" shape = Mrecord];
-        message_broker [label = "{Process: message_broker | --infrastructural--\n--message_broker--}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n}" shape = Mrecord];
+        message_broker [label = "{Process: message_broker | --infrastructural--\n--message_broker--\n}" shape = Mrecord];
         message_broker -> logging_server [label = " --restful_http--\n"]
         logging_server -> hystrix_dashboard [label = " --restful_http--\n"]
         service_registry -> message_broker [label = " --restful_http--\n"]

--- a/dataset/shabbirdwd53_springboot-microservice/model_variants/18.txt
+++ b/dataset/shabbirdwd53_springboot-microservice/model_variants/18.txt
@@ -36,7 +36,7 @@ digraph dfd2{
         api_gateway -> department_service [label = " --restful_http--\n--circuit_breaker_link--\n"]
         zipkin_server -> hystrix_dashboard [label = " --restful_http--\n"]
 
-        secret_manager [label = "{Process: secret_manager | --infrastructural--\n--secret_manager--}" shape = Mrecord];
+        secret_manager [label = "{Process: secret_manager | --infrastructural--\n--secret_manager--\n}" shape = Mrecord];
         secret_manager -> service_registry [label = " --restful_http--\n"]
         secret_manager -> config_server [label = " --restful_http--\n"]
         secret_manager -> zipkin_server [label = " --restful_http--\n"]

--- a/dataset/shabbirdwd53_springboot-microservice/model_variants/3.txt
+++ b/dataset/shabbirdwd53_springboot-microservice/model_variants/3.txt
@@ -36,7 +36,7 @@ digraph dfd2{
         api_gateway -> department_service [label = " --restful_http--\n--circuit_breaker_link--\n"]
         zipkin_server -> hystrix_dashboard [label = " --restful_http--\n"]
 
-        auth_server [label = "{Process: auth_server | --infrastructural--\n--authorization_server--}" shape = Mrecord];
+        auth_server [label = "{Process: auth_server | --infrastructural--\n--authorization_server--\n}" shape = Mrecord];
         auth_server -> service_registry [label = " --restful_http--\n"]
         auth_server -> config_server [label = " --restful_http--\n"]
         auth_server -> zipkin_server [label = " --restful_http--\n"]

--- a/dataset/shabbirdwd53_springboot-microservice/model_variants/5.txt
+++ b/dataset/shabbirdwd53_springboot-microservice/model_variants/5.txt
@@ -36,7 +36,7 @@ digraph dfd2{
         api_gateway -> department_service [label = " --restful_http--\n--circuit_breaker_link--\n"]
         zipkin_server -> hystrix_dashboard [label = " --restful_http--\n"]
 
-        auth_server [label = "{Process: auth_server | --infrastructural--\n--authorization_server--}" shape = Mrecord];
+        auth_server [label = "{Process: auth_server | --infrastructural--\n--authorization_server--\n}" shape = Mrecord];
         auth_server -> service_registry [label = " --restful_http--\n"]
         auth_server -> config_server [label = " --restful_http--\n"]
         auth_server -> zipkin_server [label = " --restful_http--\n"]

--- a/dataset/shabbirdwd53_springboot-microservice/model_variants/6.txt
+++ b/dataset/shabbirdwd53_springboot-microservice/model_variants/6.txt
@@ -36,7 +36,7 @@ digraph dfd2{
         api_gateway -> department_service [label = " --restful_http--\n--circuit_breaker_link--\n"]
         zipkin_server -> hystrix_dashboard [label = " --restful_http--\n"]
 
-        auth_server [label = "{Process: auth_server | --infrastructural--\n--authorization_server--\n--login_attempts_regulation--}" shape = Mrecord];
+        auth_server [label = "{Process: auth_server | --infrastructural--\n--authorization_server--\n--login_attempts_regulation--\n}" shape = Mrecord];
         auth_server -> service_registry [label = " --restful_http--\n"]
         auth_server -> config_server [label = " --restful_http--\n"]
         auth_server -> zipkin_server [label = " --restful_http--\n"]

--- a/dataset/shabbirdwd53_springboot-microservice/model_variants/9.txt
+++ b/dataset/shabbirdwd53_springboot-microservice/model_variants/9.txt
@@ -36,7 +36,7 @@ digraph dfd2{
         api_gateway -> department_service [label = " --restful_http--\n--circuit_breaker_link--\n"]
         zipkin_server -> hystrix_dashboard [label = " --restful_http--\n"]
 
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n}" shape = Mrecord];
         logging_server -> hystrix_dashboard [label = " --restful_http--\n"]
 
 }

--- a/dataset/spring-petclinic_spring-petclinic-microservices/model_variants/10.txt
+++ b/dataset/spring-petclinic_spring-petclinic-microservices/model_variants/10.txt
@@ -49,7 +49,7 @@ digraph dfd2{
         api_gateway -> customers_service [label = " --restful_http--\n--load_balanced_link--\n--circuit_breaker_link--\n"]
         api_gateway -> tracing_server [label = " --restful_http--\n--load_balanced_link--\n"]
 
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n}" shape = Mrecord];
         logging_server -> grafana_server [label = " --restful_http--\n"]
         config_server -> logging_server [label = " --restful_http--\n"]
         discovery_server -> logging_server [label = " --restful_http--\n"]

--- a/dataset/spring-petclinic_spring-petclinic-microservices/model_variants/11.txt
+++ b/dataset/spring-petclinic_spring-petclinic-microservices/model_variants/11.txt
@@ -49,7 +49,7 @@ digraph dfd2{
         api_gateway -> customers_service [label = " --restful_http--\n--load_balanced_link--\n--circuit_breaker_link--\n"]
         api_gateway -> tracing_server [label = " --restful_http--\n--load_balanced_link--\n"]
 
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n}" shape = Mrecord];
         logging_server -> grafana_server [label = " --restful_http--\n"]
         config_server -> logging_server [label = " --restful_http--\n"]
         discovery_server -> logging_server [label = " --restful_http--\n"]

--- a/dataset/spring-petclinic_spring-petclinic-microservices/model_variants/12.txt
+++ b/dataset/spring-petclinic_spring-petclinic-microservices/model_variants/12.txt
@@ -49,9 +49,9 @@ digraph dfd2{
         api_gateway -> customers_service [label = " --restful_http--\n--load_balanced_link--\n--circuit_breaker_link--\n"]
         api_gateway -> tracing_server [label = " --restful_http--\n--load_balanced_link--\n"]
 
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n}" shape = Mrecord];
         logging_server -> grafana_server [label = " --restful_http--\n"]
-        message_broker [label = "{Process: message_broker | --infrastructural--\n--message_broker--}" shape = Mrecord];
+        message_broker [label = "{Process: message_broker | --infrastructural--\n--message_broker--\n}" shape = Mrecord];
         message_broker -> logging_server [label = " --restful_http--\n"]
         config_server -> message_broker [label = " --restful_http--\n"]
         discovery_server -> message_broker [label = " --restful_http--\n"]

--- a/dataset/spring-petclinic_spring-petclinic-microservices/model_variants/18.txt
+++ b/dataset/spring-petclinic_spring-petclinic-microservices/model_variants/18.txt
@@ -49,7 +49,7 @@ digraph dfd2{
         api_gateway -> customers_service [label = " --restful_http--\n--load_balanced_link--\n--circuit_breaker_link--\n"]
         api_gateway -> tracing_server [label = " --restful_http--\n--load_balanced_link--\n"]
 
-        secret_manager [label = "{Process: secret_manager | --infrastructural--\n--secret_manager--}" shape = Mrecord];
+        secret_manager [label = "{Process: secret_manager | --infrastructural--\n--secret_manager--\n}" shape = Mrecord];
         secret_manager -> config_server [label = " --restful_http--\n"]
         secret_manager -> discovery_server [label = " --restful_http--\n"]
         secret_manager -> tracing_server [label = " --restful_http--\n"]

--- a/dataset/spring-petclinic_spring-petclinic-microservices/model_variants/3.txt
+++ b/dataset/spring-petclinic_spring-petclinic-microservices/model_variants/3.txt
@@ -49,7 +49,7 @@ digraph dfd2{
         api_gateway -> customers_service [label = " --restful_http--\n--load_balanced_link--\n--circuit_breaker_link--\n"]
         api_gateway -> tracing_server [label = " --restful_http--\n--load_balanced_link--\n"]
 
-        auth_server [label = "{Process: auth_server | --infrastructural--\n--authorization_server--}" shape = Mrecord];
+        auth_server [label = "{Process: auth_server | --infrastructural--\n--authorization_server--\n}" shape = Mrecord];
         auth_server -> config_server [label = " --restful_http--\n"]
         auth_server -> discovery_server [label = " --restful_http--\n"]
         auth_server -> tracing_server [label = " --restful_http--\n"]

--- a/dataset/spring-petclinic_spring-petclinic-microservices/model_variants/5.txt
+++ b/dataset/spring-petclinic_spring-petclinic-microservices/model_variants/5.txt
@@ -49,7 +49,7 @@ digraph dfd2{
         api_gateway -> customers_service [label = " --restful_http--\n--load_balanced_link--\n--circuit_breaker_link--\n"]
         api_gateway -> tracing_server [label = " --restful_http--\n--load_balanced_link--\n"]
 
-        auth_server [label = "{Process: auth_server | --infrastructural--\n--authorization_server--}" shape = Mrecord];
+        auth_server [label = "{Process: auth_server | --infrastructural--\n--authorization_server--\n}" shape = Mrecord];
         auth_server -> config_server [label = " --restful_http--\n"]
         auth_server -> discovery_server [label = " --restful_http--\n"]
         auth_server -> tracing_server [label = " --restful_http--\n"]

--- a/dataset/spring-petclinic_spring-petclinic-microservices/model_variants/6.txt
+++ b/dataset/spring-petclinic_spring-petclinic-microservices/model_variants/6.txt
@@ -49,7 +49,7 @@ digraph dfd2{
         api_gateway -> customers_service [label = " --restful_http--\n--load_balanced_link--\n--circuit_breaker_link--\n"]
         api_gateway -> tracing_server [label = " --restful_http--\n--load_balanced_link--\n"]
 
-        auth_server [label = "{Process: auth_server | --infrastructural--\n--authorization_server--\n--login_attempts_regulation--}" shape = Mrecord];
+        auth_server [label = "{Process: auth_server | --infrastructural--\n--authorization_server--\n--login_attempts_regulation--\n}" shape = Mrecord];
         auth_server -> config_server [label = " --restful_http--\n"]
         auth_server -> discovery_server [label = " --restful_http--\n"]
         auth_server -> tracing_server [label = " --restful_http--\n"]

--- a/dataset/spring-petclinic_spring-petclinic-microservices/model_variants/9.txt
+++ b/dataset/spring-petclinic_spring-petclinic-microservices/model_variants/9.txt
@@ -49,7 +49,7 @@ digraph dfd2{
         api_gateway -> customers_service [label = " --restful_http--\n--load_balanced_link--\n--circuit_breaker_link--\n"]
         api_gateway -> tracing_server [label = " --restful_http--\n--load_balanced_link--\n"]
 
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n}" shape = Mrecord];
         logging_server -> grafana_server [label = " --restful_http--\n"]
 
 }

--- a/dataset/sqshq_piggymetrics/model_variants/18.txt
+++ b/dataset/sqshq_piggymetrics/model_variants/18.txt
@@ -63,7 +63,7 @@ digraph dfd2{
         gateway -> notification_service [label = " --restful_http--\n--circuit_breaker_link--\n--load_balanced_link--\n'Load Balancer': Ribbon\n 'Circuit Breaker': Hystrix\n"]
         gateway -> auth_service [label = " --restful_http--\n--circuit_breaker_link--\n--load_balanced_link--\n--auth_provider--\n'Load Balancer': Ribbon\n 'Circuit Breaker': Hystrix\n"]
 
-        secret_manager [label = "{Process: secret_manager | --infrastructural--\n--secret_manager--}" shape = Mrecord];
+        secret_manager [label = "{Process: secret_manager | --infrastructural--\n--secret_manager--\n}" shape = Mrecord];
         config -> secret_manager [label = " --restful_http--\n"]
         registry -> secret_manager [label = " --restful_http--\n"]
         monitoring -> secret_manager [label = " --restful_http--\n"]

--- a/dataset/yidongnan_spring-cloud-netflix-example/model_variants/10.txt
+++ b/dataset/yidongnan_spring-cloud-netflix-example/model_variants/10.txt
@@ -48,7 +48,7 @@ digraph dfd2{
         zuul -> zipkin [label = " --restful_http--\n"]
         zuul -> config_server [label = " --restful_http--\n"]
 
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n}" shape = Mrecord];
         logging_server -> hystrix_dashboard [label = " --restful_http--\n"]
         admin_dashboard -> logging_server [label = " --restful_http--\n"]
         eureka_server -> logging_server [label = " --restful_http--\n"]

--- a/dataset/yidongnan_spring-cloud-netflix-example/model_variants/11.txt
+++ b/dataset/yidongnan_spring-cloud-netflix-example/model_variants/11.txt
@@ -48,7 +48,7 @@ digraph dfd2{
         zuul -> zipkin [label = " --restful_http--\n"]
         zuul -> config_server [label = " --restful_http--\n"]
 
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n}" shape = Mrecord];
         logging_server -> hystrix_dashboard [label = " --restful_http--\n"]
         admin_dashboard -> logging_server [label = " --restful_http--\n"]
         eureka_server -> logging_server [label = " --restful_http--\n"]

--- a/dataset/yidongnan_spring-cloud-netflix-example/model_variants/12.txt
+++ b/dataset/yidongnan_spring-cloud-netflix-example/model_variants/12.txt
@@ -48,7 +48,7 @@ digraph dfd2{
         zuul -> zipkin [label = " --restful_http--\n"]
         zuul -> config_server [label = " --restful_http--\n"]
 
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n}" shape = Mrecord];
         logging_server -> hystrix_dashboard [label = " --restful_http--\n"]
         eureka_server -> rabbitmq [label = " --restful_http--\n"]
         rabbitmq -> logging_server [label = " --restful_http--\n"]

--- a/dataset/yidongnan_spring-cloud-netflix-example/model_variants/18.txt
+++ b/dataset/yidongnan_spring-cloud-netflix-example/model_variants/18.txt
@@ -48,7 +48,7 @@ digraph dfd2{
         zuul -> zipkin [label = " --restful_http--\n"]
         zuul -> config_server [label = " --restful_http--\n"]
 
-        secret_manager [label = "{Process: secret_manager | --infrastructural--\n--secret_manager--}" shape = Mrecord];
+        secret_manager [label = "{Process: secret_manager | --infrastructural--\n--secret_manager--\n}" shape = Mrecord];
         secret_manager -> admin_dashboard [label = " --restful_http--\n"]
         secret_manager -> eureka_server [label = " --restful_http--\n"]
         secret_manager -> rabbitmq [label = " --restful_http--\n"]

--- a/dataset/yidongnan_spring-cloud-netflix-example/model_variants/3.txt
+++ b/dataset/yidongnan_spring-cloud-netflix-example/model_variants/3.txt
@@ -48,7 +48,7 @@ digraph dfd2{
         zuul -> zipkin [label = " --restful_http--\n"]
         zuul -> config_server [label = " --restful_http--\n"]
 
-        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--}" shape = Mrecord];
+        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--\n}" shape = Mrecord];
         authorization_server -> admin_dashboard [label = " --restful_http--\n"]
         authorization_server -> eureka_server [label = " --restful_http--\n"]
         authorization_server -> rabbitmq [label = " --restful_http--\n"]

--- a/dataset/yidongnan_spring-cloud-netflix-example/model_variants/5.txt
+++ b/dataset/yidongnan_spring-cloud-netflix-example/model_variants/5.txt
@@ -48,7 +48,7 @@ digraph dfd2{
         zuul -> zipkin [label = " --restful_http--\n"]
         zuul -> config_server [label = " --restful_http--\n"]
 
-        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--}" shape = Mrecord];
+        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--\n}" shape = Mrecord];
         authorization_server -> admin_dashboard [label = " --restful_http--\n"]
         authorization_server -> eureka_server [label = " --restful_http--\n"]
         authorization_server -> rabbitmq [label = " --restful_http--\n"]

--- a/dataset/yidongnan_spring-cloud-netflix-example/model_variants/6.txt
+++ b/dataset/yidongnan_spring-cloud-netflix-example/model_variants/6.txt
@@ -48,7 +48,7 @@ digraph dfd2{
         zuul -> zipkin [label = " --restful_http--\n"]
         zuul -> config_server [label = " --restful_http--\n"]
 
-        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--\n--login_attempts_regulation--}" shape = Mrecord];
+        authorization_server [label = "{Process: authorization_server | --infrastructural--\n--authorization_server--\n--login_attempts_regulation--\n}" shape = Mrecord];
         authorization_server -> admin_dashboard [label = " --restful_http--\n"]
         authorization_server -> eureka_server [label = " --restful_http--\n"]
         authorization_server -> rabbitmq [label = " --restful_http--\n"]

--- a/dataset/yidongnan_spring-cloud-netflix-example/model_variants/9.txt
+++ b/dataset/yidongnan_spring-cloud-netflix-example/model_variants/9.txt
@@ -48,7 +48,7 @@ digraph dfd2{
         zuul -> zipkin [label = " --restful_http--\n"]
         zuul -> config_server [label = " --restful_http--\n"]
 
-        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--}" shape = Mrecord];
+        logging_server [label = "{Process: logging_server | --infrastructural--\n--logging_server--\n}" shape = Mrecord];
         logging_server -> hystrix_dashboard [label = " --restful_http--\n"]
 
 }


### PR DESCRIPTION
This PR adresses some issues in the models that we found during the further testing in #https://github.com/DataFlowAnalysis/DataFlowAnalysis/pull/128::

The missing \n in front of '}" shape = Mrecord' caused the converter to add the string to the label.  A label with the '}" shape = Mrecord' string caused automated reading and analysis to break at a later point.

GaLiGrü aus Karlsruhe
